### PR TITLE
check that there is a password item in the $user_data array

### DIFF
--- a/core/MY_Controller.php
+++ b/core/MY_Controller.php
@@ -104,7 +104,7 @@ class Application extends CI_Controller
 			$user_data = $this->ag_auth->get_user($username, $field_type);
 			
 			
-			if($user_data['password'] === $password)
+			if(array_key_exists('password', $user_data) AND $user_data['password'] === $password)
 			{
 				
 				unset($user_data['password']);


### PR DESCRIPTION
Changed if statement to check that the password key exists in the $user_data array so as not to show an array error if they entered an invalid username.
